### PR TITLE
Support packed YCbCr format

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://oiv4p8ii3am4"]
+[gd_scene load_steps=11 format=3 uid="uid://oiv4p8ii3am4"]
 
 [ext_resource type="Script" uid="uid://dxaoavn781kxe" path="res://scripts/Main.gd" id="2_1xqyj"]
 [ext_resource type="Shader" uid="uid://dhjh7s6i7jnlp" path="res://shaders/ycbcr_to_rgb.gdshader" id="2_d14r3"]
@@ -9,11 +9,14 @@
 
 [sub_resource type="CameraTexture" id="CameraTexture_xep8u"]
 
+[sub_resource type="CameraTexture" id="CameraTexture_rvslj"]
+
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_lgiw1"]
 shader = ExtResource("2_d14r3")
 shader_parameter/rgb_texture = SubResource("CameraTexture_nyeft")
 shader_parameter/y_texture = SubResource("CameraTexture_xep8u")
 shader_parameter/cbcr_texture = SubResource("CameraTexture_7c2aw")
+shader_parameter/ycbcr_texture = SubResource("CameraTexture_rvslj")
 shader_parameter/mode = 0
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1"]

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -152,9 +152,11 @@ func _on_frame_changed() -> void:
 	var rgb_texture: CameraTexture = mat.get_shader_parameter("rgb_texture")
 	var y_texture: CameraTexture = mat.get_shader_parameter("y_texture")
 	var cbcr_texture: CameraTexture = mat.get_shader_parameter("cbcr_texture")
+	var ycbcr_texture: CameraTexture = mat.get_shader_parameter("ycbcr_texture")
 	rgb_texture.which_feed = CameraServer.FeedImage.FEED_RGBA_IMAGE
 	y_texture.which_feed = CameraServer.FeedImage.FEED_Y_IMAGE
 	cbcr_texture.which_feed = CameraServer.FeedImage.FEED_CBCR_IMAGE
+	ycbcr_texture.which_feed = CameraServer.FEED_YCBCR_IMAGE
 	match datatype:
 		CameraFeed.FeedDataType.FEED_RGB:
 			rgb_texture.camera_feed_id = camera_feed.get_id()
@@ -168,9 +170,11 @@ func _on_frame_changed() -> void:
 			mat.set_shader_parameter("cbcr_texture", cbcr_texture)
 			mat.set_shader_parameter("mode", 1)
 			preview_size = y_texture.get_size()
-		_:
-			print("YCbCr format not fully implemented yet")
-			return
+		CameraFeed.FeedDataType.FEED_YCBCR:
+			ycbcr_texture.camera_feed_id = camera_feed.get_id()
+			mat.set_shader_parameter("ycbcr_texture", ycbcr_texture)
+			mat.set_shader_parameter("mode", 2)
+			preview_size = ycbcr_texture.get_size()
 	var white_image := Image.create(int(preview_size.x), int(preview_size.y), false, Image.FORMAT_RGBA8)
 	white_image.fill(Color.WHITE)
 	camera_preview.texture = ImageTexture.create_from_image(white_image)

--- a/shaders/ycbcr_to_rgb.gdshader
+++ b/shaders/ycbcr_to_rgb.gdshader
@@ -5,14 +5,25 @@ uniform sampler2D rgb_texture;
 uniform sampler2D y_texture;
 // CbCr component texture (Feed ID 2 -> FEED_CBCR_IMAGE)
 uniform sampler2D cbcr_texture;
-// mode: 0 -> RGB, mode: 1 -> YCbCr
-uniform int mode : hint_range(0, 1);
+// YCbCr component texture (Feed ID 1 -> FEED_YCBCR_IMAGE)
+uniform sampler2D ycbcr_texture;
+// mode: 0 -> RGB, mode: 1 -> YCbCr_sep, mode: 2 -> YCbCr
+uniform int mode : hint_range(0, 2);
 
 // YCbCr to RGB conversion (BT.601 standard)
 void fragment() {
 	vec3 color;
-	color.r = texture(y_texture, UV).r;
-	color.gb = texture(cbcr_texture, UV).rg - vec2(0.5, 0.5);
+
+	if (mode == 1) {
+		color.r = texture(y_texture, UV).r;
+		color.gb = texture(cbcr_texture, UV).rg - vec2(0.5, 0.5);
+	} else if (mode == 2) {
+		vec2 UV_u = UV - floor(mod(UV / TEXTURE_PIXEL_SIZE, 2)) * vec2(1, 0) * TEXTURE_PIXEL_SIZE;
+		vec2 UV_v = UV + (vec2(1, 0) - floor(mod(UV / TEXTURE_PIXEL_SIZE, 2))) * vec2(1, 0) * TEXTURE_PIXEL_SIZE;
+		color.r = texture(ycbcr_texture, UV).r;
+		color.g = texture(ycbcr_texture, UV_u).g - 0.5;
+		color.b = texture(ycbcr_texture, UV_v).g - 0.5;
+	}
 
 	// YCbCr -> SRGB conversion
 	// Using BT.709 which is the standard for HDTV
@@ -23,5 +34,5 @@ void fragment() {
 					* color.rgb;
 
 	vec3 rgb = texture(rgb_texture, UV).rgb;
-	COLOR = vec4(mix(rgb, color, float(mode)), 1.0);
+	COLOR = vec4(mix(rgb, color, clamp(float(mode), 0.0, 1.0)), 1.0);
 }


### PR DESCRIPTION
This PR assumes camera feeds with datatype `FEED_YCBCR` is a YUV 4:2:2 packed format following the order of YUYV.