### PR TITLE
Use `format_changed` for camera feed formats update

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -147,12 +147,13 @@ func _start_camera_feed() -> void:
 	if not camera_feed:
 		return
 
-	if not camera_feed.frame_changed.is_connected(_on_frame_changed):
-		camera_feed.frame_changed.connect(_on_frame_changed, ConnectFlags.CONNECT_ONE_SHOT)
+	if not camera_feed.format_changed.is_connected(_on_format_changed):
+		camera_feed.format_changed.connect(_on_format_changed)
 	# Start the feed
 	camera_feed.feed_is_active = true
+	_on_format_changed()
 
-func _on_frame_changed() -> void:
+func _on_format_changed() -> void:
 	var datatype := camera_feed.get_datatype() as CameraFeed.FeedDataType
 	var preview_size := Vector2.ZERO
 	var mat: ShaderMaterial = camera_preview.material


### PR DESCRIPTION
`frame_changed` in CameraFeed indicates that camera frame has been changed, but that does not guarantee changes in format (datatype, frame size).

This PR use `format_changed` instead for updating camera preview, which is emitted whenever camera frame size is changed ([source](https://github.com/godotengine/godot/blob/7fbc3a5307ff0fc435423a35a19c9601b8d1c5b5/servers/camera/camera_feed.cpp#L267)). Also remove CONNECT_ONE_SHOT flag since the signal is emitted only when frame size is different.